### PR TITLE
Fix esp8266 mqtt connection over TLS

### DIFF
--- a/mqtt-client-ESP8266/esp8266_connect_mqtt_via_tls.ino
+++ b/mqtt-client-ESP8266/esp8266_connect_mqtt_via_tls.ino
@@ -1,48 +1,31 @@
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>
-#include <WiFiClientSecureBearSSL.h>
 
 // WiFi
-const char *ssid = "WIFI SSID";
-const char *password = "WIFI password";
+const char *ssid = "[WIFI SSID]"; // Enter your WiFi name
+const char *password = "[WIFI password]";  // Enter WiFi password
 
 // MQTT Broker
-const int mqtt_port = 8883;
-const char *mqtt_broker = "broker.emqx.io";
-const char *mqtt_topic = "emqx/esp8266";
-const char *mqtt_username = "your_MQTT_username";
-const char *mqtt_password = "your_MQTT_password";
+const char *mqtt_broker = "xxxxx.ala.cn-hangzhou.emqxsl.cn"; // endpoint of your EMQX Cloud Serverless instance
+// const char *mqtt_broker = "broker.emqx.io"; // endpoint of public emqx broker
+const char *mqtt_topic = "emqx/esp8266";  // define topic
+const char *mqtt_username = "your_MQTT_username";   // username for authentication
+const char *mqtt_password = "your_MQTT_password";   // password for authentication
+const int mqtt_port = 8883; // port of MQTT over SSL
 
-// load DigiCert Global Root CA ca_cert
-const char * ca_cert = \
-  "-----BEGIN CERTIFICATE-----\n"\
-"MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\n"\
-"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n"\
-"d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n"\
-"QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\n"\
-"MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\n"\
-"b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\n"\
-"9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\n"\
-"CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\n"\
-"nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\n"\
-"43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\n"\
-"T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\n"\
-"gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\n"\
-"BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\n"\
-"TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\n"\
-"DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\n"\
-"hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\n"\
-"06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\n"\
-"PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\n"\
-"YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\n"\
-"CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4="\
-"-----END CERTIFICATE-----\n";
-
-BearSSL::WiFiClientSecure espClient;
+// init wifi client
+WiFiClientSecure espClient;
 PubSubClient client(espClient);
 
+// fingerprint of *.emqxsl.cn
+const char* fingerprint = "7E:52:D3:84:48:3C:5A:9F:A4:39:9A:8B:27:01:B1:F8:C6:AD:D4:47";
+// fingerprint of broker.emqx.io
+// const char* fingerprint = "B6 C6 FF 82 C6 59 09 BB D6 39 80 7F E7 BC 10 C9 19 C8 21 8E";
+
 void setup() {
+  // Set software serial baud to 115200;
   Serial.begin(115200);
+  // connecting to a WiFi network
   WiFi.begin(ssid, password);
   while (WiFi.status() != WL_CONNECTED) {
     delay(1000);
@@ -51,8 +34,7 @@ void setup() {
   Serial.println("Connected to the WiFi network");
 
   // connecting to a mqtt broker
-  BearSSL::X509List ca(ca_cert);
-  espClient.setTrustAnchors(&ca);
+  espClient.setFingerprint(fingerprint);
   client.setServer(mqtt_broker, mqtt_port);
   client.setCallback(callback);
   while (!client.connected()) {


### PR DESCRIPTION
esp8266 MQTT connection over TLS samples.
1. Fix the connection error with return code -2.
2. Add a sample to connect to EMQX Cloud Serverless.