### PR TITLE
Erlang WSS example fails due to non-443 TLS port

### DIFF
--- a/mqtt-client-Erlang/rebar.config
+++ b/mqtt-client-Erlang/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-        {emqtt, {git, "https://github.com/emqx/emqtt", {ref, "8550dce"}}}
+        {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.9.5"}}}
        ]}.
 
 {shell, [

--- a/mqtt-client-Erlang/rebar.config
+++ b/mqtt-client-Erlang/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-        {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.7.0"}}}
+        {emqtt, {git, "https://github.com/emqx/emqtt", {ref, "8550dce"}}}
        ]}.
 
 {shell, [

--- a/mqtt-client-Erlang/src/mqttex.erl
+++ b/mqtt-client-Erlang/src/mqttex.erl
@@ -92,8 +92,9 @@ base_options(Transport, Host, Port, ClientId) ->
             ],
     case Transport == tls orelse Transport == wss of
         true ->
-            [{ssl, true},
-             {ssl_opts, [
+            WSTransportOptions = 
+                   [{ssl, true},
+                    {ssl_opts, [
                          {cacertfile, "certs/cacert.pem"},
                          {certfile, "certs/client-cert.pem"},
                          {keyfile, "certs/client-key.pem"},
@@ -102,7 +103,20 @@ base_options(Transport, Host, Port, ClientId) ->
                          %% or enable verify the server's cert
                          %{verify, verify_peer}
                         ]
-             }] ++ Basic;
+                    }]
+            ++ 
+            case Transport == wss of
+                true ->
+                    [
+                        { ws_transport_options, [
+                            {transport, tls},
+                            {protocols,[http]}
+                        ]}
+                    ];
+                _ ->
+                    []
+            end,
+            WSTransportOptions ++ Basic;
         _ ->
             Basic
     end.


### PR DESCRIPTION
The Erlang example currently in this repository uses a non-443 TLS port for wss, specifically port 8084.

As per my accepted commit to emqtt, https://github.com/emqx/emqtt/pull/213, wss requires additional configuration for this to work:

```
{ ws_transport_options, [
                            {transport, tls},
                            {protocols,[http]}
                        ]}

```
The first option is required to specify tls (obviously), since gun will only enable tls on port 443 due to this code in gun.erl:

```
default_transport(443) -> tls;
default_transport(_) -> tcp.

```
Any non-443 SSL connection would then require the "{transport, tls}" option added to ws_transport_options.

The second option is required because gun defaults to http2, which then fails. Reducing the protocols to just http allows tls to succeed and thus wss will succeed.

One or both of these may become unnecessary in future versions of gun (although I did test up to the current version and both are still issues).

This PR adds in that config so that this example works as expected.

I have changed the tag to a ref in rebar.config so that this works, but this should probably become a proper tag when emqtt PR#213 enters a version.