### PR TITLE
fix: correct variable MQTT publish function call

### DIFF
--- a/mqtt-client-ESP8266/esp8266_connect_mqtt_via_tls.ino
+++ b/mqtt-client-ESP8266/esp8266_connect_mqtt_via_tls.ino
@@ -135,7 +135,7 @@ void connectToMQTT() {
             Serial.println("Connected to MQTT broker");
             mqtt_client.subscribe(mqtt_topic);
             // Publish message upon successful connection
-            mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+            mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
         } else {
             char err_buf[128];
             espClient.getLastSSLError(err_buf, sizeof(err_buf));


### PR DESCRIPTION
The project documentation contained a typo in the line where the `mqtt_client.publish()` function is called. The variable `mqtt_topic` was incorrectly written as `topic`. This fix adjusts the `mqtt_client.publish()` call to use the correct variable, ensuring the accuracy of the documentation and the proper functionality of the code.